### PR TITLE
feat: send verification email on complaint creation (#12)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "node-fetch": "^2.7.0",
+        "nodemailer": "^7.0.6",
         "pg": "^8.16.3"
       },
       "devDependencies": {
@@ -4368,6 +4369,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
+      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "node-fetch": "^2.7.0",
+    "nodemailer": "^7.0.6",
     "pg": "^8.16.3"
   },
   "devDependencies": {

--- a/backend/src/application/services/notification.service.js
+++ b/backend/src/application/services/notification.service.js
@@ -1,0 +1,16 @@
+class NotificationService {
+  /**
+   * @param {INotifier} notifier
+   */
+  constructor(notifier) {
+    this.notifier = notifier;
+  }
+
+  async notifyComplaint({ to, entity, title, description, ip }) {
+    const subject = 'Nueva queja recibida';
+    const text = `Entidad: ${entity}\nTítulo: ${title}\nDescripción: ${description}\nIP del remitente: ${ip}`;
+    await this.notifier.send({ to, subject, text });
+  }
+}
+
+module.exports = NotificationService;

--- a/backend/src/infrastructure/controllers/complaint.controller.js
+++ b/backend/src/infrastructure/controllers/complaint.controller.js
@@ -43,13 +43,16 @@ exports.create = async (req, res, next) => {
   try {
     const complaint = await complaintService.createComplaint(req.body);
 
-    // Obtener nombre de la entidad
+    // Obtener la entidad relacionada
     let entityName = 'Desconocida';
-    if (complaint.entity_name) entityName = complaint.entity_name;
-    if (complaint.entity && complaint.entity.name) entityName = complaint.entity.name;
+    if (complaint.entity_id) {
+      const entity = await require('../../application/services/entity.service').getEntityById(complaint.entity_id);
+      if (entity && entity.name) entityName = entity.name;
+    }
 
     // Obtener IP
-    const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+    let ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+    if (ip === '::1' || ip === '::ffff:127.0.0.1') ip = '127.0.0.1';
 
     // Enviar notificación (correo)
     await notificationService.notifyComplaint({

--- a/backend/src/infrastructure/controllers/complaint.controller.js
+++ b/backend/src/infrastructure/controllers/complaint.controller.js
@@ -1,4 +1,8 @@
 const complaintService = require('../../application/services/complaint.service');
+const NodemailerNotifier = require('../../infrastructure/notifiers/nodemailer.notifier');
+const NotificationService = require('../../application/services/notification.service');
+const notifier = new NodemailerNotifier();
+const notificationService = new NotificationService(notifier);
 
 exports.getAll = async (req, res, next) => {
   try {
@@ -38,8 +42,27 @@ exports.getByEntity = async (req, res, next) => {
 exports.create = async (req, res, next) => {
   try {
     const complaint = await complaintService.createComplaint(req.body);
+
+    // Obtener nombre de la entidad
+    let entityName = 'Desconocida';
+    if (complaint.entity_name) entityName = complaint.entity_name;
+    if (complaint.entity && complaint.entity.name) entityName = complaint.entity.name;
+
+    // Obtener IP
+    const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+
+    // Enviar notificación (correo)
+    await notificationService.notifyComplaint({
+      to: process.env.NOTIFY_EMAIL_USER,
+      entity: entityName,
+      title: complaint.title,
+      description: complaint.description,
+      ip,
+    });
+
     res.status(201).json(complaint);
   } catch (err) {
+    console.error("Error al enviar correo:", err);
     next(err);
   }
 };

--- a/backend/src/infrastructure/notifiers/nodemailer.notifier.js
+++ b/backend/src/infrastructure/notifiers/nodemailer.notifier.js
@@ -1,0 +1,27 @@
+const nodemailer = require('nodemailer');
+const INotifier = require('./notifier.interface');
+
+class NodemailerNotifier extends INotifier {
+  constructor() {
+    super();
+    this.transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.NOTIFY_EMAIL_USER,
+        pass: process.env.NOTIFY_EMAIL_PASS,
+      },
+    });
+  }
+
+  async send({ to, subject, text }) {
+    const mailOptions = {
+      from: process.env.NOTIFY_EMAIL_USER,
+      to,
+      subject,
+      text,
+    };
+    await this.transporter.sendMail(mailOptions);
+  }
+}
+
+module.exports = NodemailerNotifier;

--- a/backend/src/infrastructure/notifiers/notifier.interface.js
+++ b/backend/src/infrastructure/notifiers/notifier.interface.js
@@ -1,0 +1,14 @@
+class INotifier {
+  /**
+   * Envía una notificación por correo.
+   * @param {Object} params
+   * @param {string} params.to - Correo destinatario
+   * @param {string} params.subject - Asunto
+   * @param {string} params.text - Cuerpo del mensaje
+   */
+  async send({ to, subject, text }) {
+    throw new Error('Método send() no implementado');
+  }
+}
+
+module.exports = INotifier;


### PR DESCRIPTION
This PR adds the ability to send an email defined in the backend environment variables.

The email sent includes the complaint entity, content, and the sending user's IP address.

The IP address sent is still under development, so it is a future fix.

Ref #12 