### PR TITLE
ci(frontend): add GitHub Actions workflow for build, run and test (#43)

### DIFF
--- a/.github/workflows/frontendCi.yml
+++ b/.github/workflows/frontendCi.yml
@@ -1,0 +1,49 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run build
+
+  run-frontend:
+    runs-on: ubuntu-latest
+    needs: build-frontend
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run preview & sleep 5
+
+  test-frontend:
+    runs-on: ubuntu-latest
+    needs: run-frontend
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: echo "No hay tests aún en el frontend"


### PR DESCRIPTION
## Description
This issue requests the creation of a GitHub Actions (`Frontend CI`) workflow to automate frontend checks on each push or pull request to the `main` branch.
The workflow should validate the frontend by installing dependencies, running the build, and running tests.

## Required Changes
- Add the `build-frontend` task: installs dependencies and runs `npm run build`.
- Add the `test-frontend` task: runs `npm test` to validate functionality.
- Configure these tasks to run on each push or pull request to `main`.

## Expected Behavior
- On each push or pull request to `main`, GitHub Actions:
1. Builds the frontend.
2. Runs unit and integration tests.
3. Reports errors if something fails.

##Priority
  Medium: This is important to ensure the frontend is stable and prevent faulty code from reaching `main`.