### PR TITLE
refactor(ci-release): simplify release workflow to only generate changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           release-type: node
           package-name: backend
+          skip-pull-request: true
+          command: manifest
           changelog-types: >
             [
               {"type": "feat", "section": "Features", "hidden": false},


### PR DESCRIPTION
### Description
This PR updates the `release-please` workflow configuration to simplify the release process by **disabling automatic Pull Request creation** and **generating changelogs directly**.  

The adjustment ensures that releases are generated without requiring manual intervention, improving automation reliability and consistency in the CI/CD pipeline.

### Key changes
- Added `skip-pull-request: true` to prevent automatic PR generation.  
- Added `command: manifest` to enable direct changelog and version updates.  
- Ensured the workflow continues to trigger correctly on `push` events to the `main` branch.  
- Verified that changelog updates and version bumps are properly generated without opening a PR.

### Notes
- This change affects only the release automation process; **no functional or code-level modifications** were made.  
- Improves efficiency by eliminating redundant Pull Requests.  
- Keeps the release process aligned with the Conventional Commits standard and automated changelog generation.

### Closes
Closes #90 
