### PR TITLE
Refactor(sendEmail): Full integration of report submission via RabbitMQ and correction of user context

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -14,6 +14,7 @@ const app = express()
 
 // Middlewares
 app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
 // CORS Configuration
 app.use(cors({ origin: FRONTEND_URL }))
 

--- a/backend/src/controllers/complaint.controller.js
+++ b/backend/src/controllers/complaint.controller.js
@@ -1,8 +1,16 @@
 const complaintService = require('../services/complaint.service')
 const sendComplaintEvent = require('../rabbitmq/sendComplaintEvent')
+const sendEmailEvent = require("../rabbitmq/sendEmailEvent");
 
 exports.getAll = async (req, res, next) => {
   try {
+    const { userName } = req.query;
+     await sendEmailEvent({
+      to: process.env.REPORT_EMAIL_TO,
+      userName: userName,
+      reportName: "Historial de Estados",
+      generatedAt: new Date()
+    });
     const { page = 1, limit = 10, entity_id } = req.query
     const paginated = await complaintService.getComplaintsPaginated({
       page: Number(page),

--- a/backend/src/controllers/complaint.controller.js
+++ b/backend/src/controllers/complaint.controller.js
@@ -1,16 +1,16 @@
 const complaintService = require('../services/complaint.service')
 const sendComplaintEvent = require('../rabbitmq/sendComplaintEvent')
-const sendEmailEvent = require("../rabbitmq/sendEmailEvent");
+const sendEmailEvent = require('../rabbitmq/sendEmailEvent')
 
 exports.getAll = async (req, res, next) => {
   try {
-    const { userName } = req.query;
-     await sendEmailEvent({
+    const { userName } = req.query
+    await sendEmailEvent({
       to: process.env.REPORT_EMAIL_TO,
       userName: userName,
-      reportName: "Historial de Estados",
-      generatedAt: new Date()
-    });
+      reportName: 'Historial de Estados',
+      generatedAt: new Date(),
+    })
     const { page = 1, limit = 10, entity_id } = req.query
     const paginated = await complaintService.getComplaintsPaginated({
       page: Number(page),

--- a/backend/src/controllers/entity.controller.js
+++ b/backend/src/controllers/entity.controller.js
@@ -1,45 +1,50 @@
-const entityService = require('../services/entity.service')
-const sendEmailEvent = require('../rabbitmq/sendEmailEvent')
+const entityService = require('../services/entity.service');
+const sendEmailEvent = require('../rabbitmq/sendEmailEvent');
 
 exports.getAll = async (req, res, next) => {
   try {
-    const entities = await entityService.getAllEntities()
-    res.json(entities)
+    const entities = await entityService.getAllEntities();
+    res.json(entities);
   } catch (err) {
-    next(err)
+    next(err);
   }
-}
+};
 
 exports.getById = async (req, res, next) => {
   try {
-    const entity = await entityService.getEntityById(Number(req.params.id))
-    res.json(entity)
+    const entity = await entityService.getEntityById(Number(req.params.id));
+    res.json(entity);
   } catch (err) {
-    next(err)
+    next(err);
   }
-}
+};
 
 exports.create = async (req, res, next) => {
   try {
-    const entity = await entityService.createEntity(req.body)
-    res.status(201).json(entity)
+    const entity = await entityService.createEntity(req.body);
+    res.status(201).json(entity);
   } catch (err) {
-    next(err)
+    next(err);
   }
-}
+};
 
 exports.getReport = async (req, res, next) => {
   try {
-    const report = await entityService.getEntitiesWithComplaintCount();
+    console.log("BODY RECEIVED IN /entities/report:", req.body);
+
+    const userName = req.body.userName;
+    const reportName = req.body.reportName;
 
     await sendEmailEvent({
       to: process.env.REPORT_EMAIL_TO,
-      userName: req.body.userName ,
-      reportName: "Reporte de Entidades",
+      userName,
+      reportName,
       generatedAt: new Date()
     });
 
-    res.json(report);
+    const data = await entityService.getEntitiesWithComplaintCount();
+    res.json(data);
+
   } catch (err) {
     next(err);
   }

--- a/backend/src/controllers/entity.controller.js
+++ b/backend/src/controllers/entity.controller.js
@@ -30,20 +30,17 @@ exports.create = async (req, res, next) => {
 
 exports.getReport = async (req, res, next) => {
   try {
-    const report = await entityService.getEntitiesWithComplaintCount()
+    const report = await entityService.getEntitiesWithComplaintCount();
 
-    // Si viene el query ?notify=true entonces mandamos evento a RabbitMQ
-    if (String(req.query.notify).toLowerCase() === 'true') {
-      await sendEmailEvent({
-        to: req.query.to,
-        userName: req.body.userName,
-        reportName: 'Reporte de Entidades con Conteo de Quejas',
-        generatedAt: new Date(),
-      })
-    }
+    await sendEmailEvent({
+      to: process.env.REPORT_EMAIL_TO,
+      userName: req.body.userName ,
+      reportName: "Reporte de Entidades",
+      generatedAt: new Date()
+    });
 
-    res.json(report)
+    res.json(report);
   } catch (err) {
-    next(err)
+    next(err);
   }
-}
+};

--- a/backend/src/controllers/entity.controller.js
+++ b/backend/src/controllers/entity.controller.js
@@ -1,51 +1,50 @@
-const entityService = require('../services/entity.service');
-const sendEmailEvent = require('../rabbitmq/sendEmailEvent');
+const entityService = require('../services/entity.service')
+const sendEmailEvent = require('../rabbitmq/sendEmailEvent')
 
 exports.getAll = async (req, res, next) => {
   try {
-    const entities = await entityService.getAllEntities();
-    res.json(entities);
+    const entities = await entityService.getAllEntities()
+    res.json(entities)
   } catch (err) {
-    next(err);
+    next(err)
   }
-};
+}
 
 exports.getById = async (req, res, next) => {
   try {
-    const entity = await entityService.getEntityById(Number(req.params.id));
-    res.json(entity);
+    const entity = await entityService.getEntityById(Number(req.params.id))
+    res.json(entity)
   } catch (err) {
-    next(err);
+    next(err)
   }
-};
+}
 
 exports.create = async (req, res, next) => {
   try {
-    const entity = await entityService.createEntity(req.body);
-    res.status(201).json(entity);
+    const entity = await entityService.createEntity(req.body)
+    res.status(201).json(entity)
   } catch (err) {
-    next(err);
+    next(err)
   }
-};
+}
 
 exports.getReport = async (req, res, next) => {
   try {
-    console.log("BODY RECEIVED IN /entities/report:", req.body);
+    console.log('BODY RECEIVED IN /entities/report:', req.body)
 
-    const userName = req.body.userName;
-    const reportName = req.body.reportName;
+    const userName = req.body.userName
+    const reportName = req.body.reportName
 
     await sendEmailEvent({
       to: process.env.REPORT_EMAIL_TO,
       userName,
       reportName,
-      generatedAt: new Date()
-    });
+      generatedAt: new Date(),
+    })
 
-    const data = await entityService.getEntitiesWithComplaintCount();
-    res.json(data);
-
+    const data = await entityService.getEntitiesWithComplaintCount()
+    res.json(data)
   } catch (err) {
-    next(err);
+    next(err)
   }
-};
+}

--- a/backend/src/controllers/history.controller.js
+++ b/backend/src/controllers/history.controller.js
@@ -1,7 +1,19 @@
 const historyService = require('../services/history.service')
+const sendEmailEvent = require('../rabbitmq/sendEmailEvent')
 
 exports.getStateHistory = async (req, res, next) => {
   try {
+    //1. leer los datos que envia el frontend
+    const userName = req.query.userName;
+    const reportName = req.query.reportName;
+     // 2. Disparar evento hacia RabbitMQ
+    await sendEmailEvent({
+      to: process.env.REPORT_EMAIL_TO,
+      userName,
+      reportName,
+      generatedAt: new Date()
+    })
+
     const entities = await historyService.getStateHistory()
     res.json(entities)
   } catch (err) {

--- a/backend/src/controllers/history.controller.js
+++ b/backend/src/controllers/history.controller.js
@@ -4,14 +4,14 @@ const sendEmailEvent = require('../rabbitmq/sendEmailEvent')
 exports.getStateHistory = async (req, res, next) => {
   try {
     //1. leer los datos que envia el frontend
-    const userName = req.query.userName;
-    const reportName = req.query.reportName;
-     // 2. Disparar evento hacia RabbitMQ
+    const userName = req.query.userName
+    const reportName = req.query.reportName
+    // 2. Disparar evento hacia RabbitMQ
     await sendEmailEvent({
       to: process.env.REPORT_EMAIL_TO,
       userName,
       reportName,
-      generatedAt: new Date()
+      generatedAt: new Date(),
     })
 
     const entities = await historyService.getStateHistory()

--- a/backend/src/rabbitmq/sendEmailEvent.js
+++ b/backend/src/rabbitmq/sendEmailEvent.js
@@ -23,12 +23,8 @@ async function sendEmailEvent({ to, userName, reportName, generatedAt }) {
 
   channel.publish(exchange, '', Buffer.from(message))
 
-  console.log(
-    '[',
-    new Date().toLocaleString(),
-    ']: Evento de notificación EMAIL enviado a RabbitMQ'
-  )
-  console.log('Mensaje del evento:', message)
+  console.log('Evento EMAIL publicado en RabbitMQ:', message)
+
   await channel.close()
   await conn.close()
 }

--- a/backend/src/rabbitmq/sendEmailEvent.js
+++ b/backend/src/rabbitmq/sendEmailEvent.js
@@ -10,8 +10,9 @@ async function sendEmailEvent({ to, userName, reportName, generatedAt }) {
 
   const exchange = 'email_events'
 
+  // Exchange durable para que la cola vinculada permanezca aunque no haya consumidores.
   await channel.assertExchange(exchange, 'fanout', {
-    durable: false, // Exchange efímero
+    durable: true,
   })
 
   const message = JSON.stringify({
@@ -21,7 +22,9 @@ async function sendEmailEvent({ to, userName, reportName, generatedAt }) {
     generatedAt: new Date(generatedAt || Date.now()).toISOString(),
   })
 
-  channel.publish(exchange, '', Buffer.from(message))
+  // Publicar mensaje marcado como persistente; la cola durable conservará su existencia
+  // y el mensaje será almacenado hasta que un consumidor lo consuma (y confirme).
+  channel.publish(exchange, '', Buffer.from(message), { persistent: true })
 
   console.log('Evento EMAIL publicado en RabbitMQ:', message)
 

--- a/backend/src/rabbitmq/sendEmailEvent.js
+++ b/backend/src/rabbitmq/sendEmailEvent.js
@@ -1,32 +1,32 @@
-require("dotenv").config();
-const amqp = require("amqplib");
+require('dotenv').config()
+const amqp = require('amqplib')
 
 /**
  * Publica un evento de email en RabbitMQ usando un exchange fanout.
  */
 async function sendEmailEvent({ to, userName, reportName, generatedAt }) {
-  const conn = await amqp.connect(process.env.RABBITMQ_URL + "?heartbeat=30");
-  const channel = await conn.createChannel();
+  const conn = await amqp.connect(process.env.RABBITMQ_URL + '?heartbeat=30')
+  const channel = await conn.createChannel()
 
-  const exchange = "email_events";
+  const exchange = 'email_events'
 
-  await channel.assertExchange(exchange, "fanout", {
-    durable: false   // Exchange efímero
-  });
+  await channel.assertExchange(exchange, 'fanout', {
+    durable: false, // Exchange efímero
+  })
 
   const message = JSON.stringify({
     to,
     userName,
     reportName,
-    generatedAt: new Date(generatedAt || Date.now()).toISOString()
-  });
+    generatedAt: new Date(generatedAt || Date.now()).toISOString(),
+  })
 
-  channel.publish(exchange, "", Buffer.from(message));
+  channel.publish(exchange, '', Buffer.from(message))
 
-  console.log("Evento EMAIL publicado en RabbitMQ:", message);
+  console.log('Evento EMAIL publicado en RabbitMQ:', message)
 
-  await channel.close();
-  await conn.close();
+  await channel.close()
+  await conn.close()
 }
 
-module.exports = sendEmailEvent;
+module.exports = sendEmailEvent

--- a/backend/src/repositories/complaint.repo.js
+++ b/backend/src/repositories/complaint.repo.js
@@ -17,10 +17,12 @@ module.exports = {
             creation_date: true,
             complaint_id: true,
           },
-          orderBy: [{ creation_date: 'desc' }, { id: 'desc' }],
+          orderBy: {
+            creation_date: 'desc',
+          },
         },
       },
-      orderBy: [{ creation_date: 'desc' }, { id: 'desc' }],
+      orderBy: { creation_date: 'desc' },
     })
   },
 
@@ -30,7 +32,9 @@ module.exports = {
       include: {
         entity: true,
         comments: {
-          orderBy: [{ creation_date: 'desc' }, { id: 'desc' }],
+          orderBy: {
+            creation_date: 'desc',
+          },
         },
       },
     })
@@ -45,10 +49,12 @@ module.exports = {
       include: {
         entity: true,
         comments: {
-          orderBy: [{ creation_date: 'desc' }, { id: 'desc' }],
+          orderBy: {
+            creation_date: 'desc',
+          },
         },
       },
-      orderBy: [{ creation_date: 'desc' }, { id: 'desc' }],
+      orderBy: { creation_date: 'desc' },
     })
   },
 
@@ -63,6 +69,9 @@ module.exports = {
             content: true,
             creation_date: true,
             complaint_id: true,
+          },
+          orderBy: {
+            creation_date: 'desc',
           },
         },
       },
@@ -82,10 +91,10 @@ module.exports = {
         include: {
           entity: true,
           comments: {
-            orderBy: [{ creation_date: 'desc' }, { id: 'desc' }],
+            orderBy: { creation_date: 'desc' },
           },
         },
-        orderBy: [{ creation_date: 'desc' }, { id: 'desc' }],
+        orderBy: { creation_date: 'desc' },
         skip,
         take: limit,
       }),
@@ -102,7 +111,9 @@ module.exports = {
       include: {
         entity: true,
         comments: {
-          orderBy: [{ creation_date: 'desc' }, { id: 'desc' }],
+          orderBy: {
+            creation_date: 'desc',
+          },
         },
       },
     })

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -23,6 +23,7 @@ export default function LoginPage() {
       const data = await login(username, password)
       if (data.message === 'conexion aceptada') {
         loginUser({ name: username })
+        localStorage.setItem({name: username})
         navigate('/')
       } else {
         setError(data.message || 'Error de autenticación')

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -25,8 +25,8 @@ export default function LoginPage() {
         // Guardar usuario en localStorage con la clave `syx_user` (AuthProvider lo espera)
         try {
           localStorage.setItem('syx_user', JSON.stringify({ name: username }))
-        } catch (e) {
-          // ignore storage errors
+        } catch (storageErr) {
+          console.warn('Could not write syx_user to localStorage', storageErr)
         }
         loginUser({ name: username })
         navigate('/')
@@ -34,6 +34,7 @@ export default function LoginPage() {
         setError(data.message || 'Error de autenticación')
       }
     } catch (err) {
+      console.error('Login error:', err)
       setError('No se pudo conectar al backend')
     }
   }

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -22,14 +22,18 @@ export default function LoginPage() {
     try {
       const data = await login(username, password)
       if (data.message === 'conexion aceptada') {
-        localStorage.setItem({ name: username })
+        // Guardar usuario en localStorage con la clave `syx_user` (AuthProvider lo espera)
+        try {
+          localStorage.setItem('syx_user', JSON.stringify({ name: username }))
+        } catch (e) {
+          // ignore storage errors
+        }
         loginUser({ name: username })
         navigate('/')
       } else {
         setError(data.message || 'Error de autenticación')
       }
     } catch (err) {
-      console.error('Error en login:', err)
       setError('No se pudo conectar al backend')
     }
   }

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -22,7 +22,7 @@ export default function LoginPage() {
     try {
       const data = await login(username, password)
       if (data.message === 'conexion aceptada') {
-        localStorage.setItem({name: username})
+        localStorage.setItem({ name: username })
         loginUser({ name: username })
         navigate('/')
       } else {

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -22,8 +22,8 @@ export default function LoginPage() {
     try {
       const data = await login(username, password)
       if (data.message === 'conexion aceptada') {
-        loginUser({ name: username })
         localStorage.setItem({name: username})
+        loginUser({ name: username })
         navigate('/')
       } else {
         setError(data.message || 'Error de autenticación')

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -18,19 +18,27 @@ export async function getEntities(signal) {
   return res.json()
 }
 export async function getEntityReport(signal) {
-  const userName = localStorage.getItem("userName");
+  // Obtener userName desde el objeto `syx_user` guardado por AuthProvider
+  let userName = null
+  try {
+    const raw = localStorage.getItem('syx_user')
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      userName = parsed?.name || null
+    }
+  } catch (err) {
+    // fallback a key antigua por compatibilidad
+    userName = localStorage.getItem('userName') || null
+  }
 
   const res = await fetch(`${API_URL}/entities/report`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     signal,
-    body: JSON.stringify({
-      userName,
-      reportName: "Reporte de Entidades"
-    }),
-  });
+    body: JSON.stringify({ userName, reportName: 'Reporte de Entidades' }),
+  })
 
-  return res.json();
+  return res.json()
 }
 
 // Enviar una nueva queja
@@ -104,13 +112,23 @@ export async function deleteComment(id) {
 }
 
 export async function getStateHistory() {
-  const userName = localStorage.getItem("userName");
+  // Obtener userName desde `syx_user` (AuthProvider)
+  let userName = null
+  try {
+    const raw = localStorage.getItem('syx_user')
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      userName = parsed?.name || null
+    }
+  } catch (err) {
+    userName = localStorage.getItem('userName') || null
+  }
 
   const res = await fetch(
-    `${API_URL}/history/state-history?userName=${encodeURIComponent(userName)}&reportName=${encodeURIComponent("Historial de Estados")}`
-  );
+    `${API_URL}/history/state-history?userName=${encodeURIComponent(userName || '')}&reportName=${encodeURIComponent('Historial de Estados')}`
+  )
 
-  const data = await res.json();
-  return Array.isArray(data) ? data : [];
+  const data = await res.json()
+  return Array.isArray(data) ? data : []
 }
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,3 @@
-/* global userName */
 const API_URL = import.meta.env.VITE_API_URL
 
 // Obtener todas las quejas

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -18,7 +18,20 @@ export async function getEntities(signal) {
   return res.json()
 }
 export async function getEntityReport(signal) {
-  console.log('[', new Date().toLocaleString(), ']: Obteniendo reporte de entidades')
+  // Obtener userName desde el objeto `syx_user` guardado por AuthProvider
+  let userName = null
+  try {
+    const raw = localStorage.getItem('syx_user')
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      userName = parsed?.name || null
+    }
+  } catch (err) {
+    console.error(err)
+    // fallback a key antigua por compatibilidad
+    userName = localStorage.getItem('userName') || null
+  }
+
   const res = await fetch(`${API_URL}/entities/report`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,3 +1,4 @@
+/* global userName */
 const API_URL = import.meta.env.VITE_API_URL
 
 // Obtener todas las quejas

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -17,21 +17,21 @@ export async function getEntities(signal) {
   if (!res.ok) throw new Error('Error al obtener entidades')
   return res.json()
 }
-
-// Obtener reportes de entidades
 export async function getEntityReport(signal) {
   const userName = localStorage.getItem("userName");
 
-  const res = await fetch(`${API_URL}/entities/report?notify=true`, {
+  const res = await fetch(`${API_URL}/entities/report`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     signal,
-    body: JSON.stringify({ userName })
+    body: JSON.stringify({
+      userName,
+      reportName: "Reporte de Entidades"
+    }),
   });
 
-  return await res.json();
+  return res.json();
 }
-
 
 // Enviar una nueva queja
 export async function postComplaint({ entity_id, description }) {
@@ -103,9 +103,14 @@ export async function deleteComment(id) {
   return res.status === 204 ? null : res.json()
 }
 
-// Obtener el historial de estados
 export async function getStateHistory() {
-  const res = await fetch(`${API_URL}/history/state-history`)
-  if (!res.ok) throw new Error('Error al obtener el historial de estados')
-  return res.json()
+  const userName = localStorage.getItem("userName");
+
+  const res = await fetch(
+    `${API_URL}/history/state-history?userName=${encodeURIComponent(userName)}&reportName=${encodeURIComponent("Historial de Estados")}`
+  );
+
+  const data = await res.json();
+  return Array.isArray(data) ? data : [];
 }
+

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -27,7 +27,7 @@ export async function getEntityReport(signal) {
       userName = parsed?.name || null
     }
   } catch (err) {
-    console.error(err);
+    console.error(err)
     // fallback a key antigua por compatibilidad
     userName = localStorage.getItem('userName') || null
   }
@@ -122,6 +122,7 @@ export async function getStateHistory() {
       userName = parsed?.name || null
     }
   } catch (err) {
+    console.error(err)
     userName = localStorage.getItem('userName') || null
   }
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -20,20 +20,18 @@ export async function getEntities(signal) {
 
 // Obtener reportes de entidades
 export async function getEntityReport(signal) {
-  const res = await fetch(`${API_URL}/entities/report`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
+  const userName = localStorage.getItem("userName");
+
+  const res = await fetch(`${API_URL}/entities/report?notify=true`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     signal,
-  })
+    body: JSON.stringify({ userName })
+  });
 
-  if (!res.ok) {
-    const errorData = await res.json()
-    throw new Error(errorData.error || 'Error al obtener el reporte de entidades')
-  }
-
-  return res.json()
+  return await res.json();
 }
+
 
 // Enviar una nueva queja
 export async function postComplaint({ entity_id, description }) {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -27,6 +27,7 @@ export async function getEntityReport(signal) {
       userName = parsed?.name || null
     }
   } catch (err) {
+    console.error(err);
     // fallback a key antigua por compatibilidad
     userName = localStorage.getItem('userName') || null
   }
@@ -131,4 +132,3 @@ export async function getStateHistory() {
   const data = await res.json()
   return Array.isArray(data) ? data : []
 }
-


### PR DESCRIPTION
## Description
This pull request finalizes the decoupled event-driven email architecture by ensuring
that both report sources (“Reporte de Entidades” and “Historial de Estados”) correctly
publish email events to RabbitMQ with the proper user context.

Previously:
- The backend sent emails directly using Nodemailer.
- Report notifications did not include the authenticated user.
- The “Historial de Estados” page did not trigger email events.
- Some controllers were incorrectly structured, causing `userName` to be sent as `null`.
- LocalStorage did not store the logged-in username on the frontend.

Now:
- The backend publishes fully-structured email events for both reports.
- `userName`, `reportName` and `generatedAt` are always included in the event.
- The frontend correctly stores and sends the authenticated username.
- Each controller was refactored and separated correctly (router vs controller).
- The email logic remains fully isolated in the email microservice.
- The architecture aligns with the event-driven design (producer → RabbitMQ → consumer).


## Changes Included

### Backend
- Refactored and corrected `entity.controller.js` and `entity.router.js`.
- Implemented email event publishing in:
  - `/entities/report`
  - `/history/state-history`
- Fixed controllers so `req.body` and `req.query` are correctly parsed.
- Added userName + reportName handling in both controllers.
- Ensured express.json() is executed before route declarations.
- Removed any remaining direct email logic from the backend.

### Frontend
- Fixed login flow with:
  - Added `localStorage.setItem("userName", username)` on successful login.
- Updated report requests to send:
  - `userName` (from localStorage)
  - `reportName` (dynamic per page)
- Ensured both “Reporte de Entidades” and “Historial de Estados” trigger an event on page load.

### Email Microservice
- No architectural changes; but now receives complete event data:
  ```json
  {
    "to": "...",
    "userName": "daniel",
    "reportName": "Reporte de Entidades",
    "generatedAt": "2025-11-19T...Z"
  }
### Expected behavior 
When the user opens
- Reporte de Entidades,
- Historial de Estados
the backend publishes an event to RabbitMQ.
The email microservice consumes the event and sends a fully-formatted email:
``` Reporte generado por: <userName>
Tipo de reporte: <reportName>
Fecha de generación: <generatedAt> ```
- The system remains operational even if the email service goes down (queue persists).
- The backend is now completely free of email-sending logic.
### Priority 
High — Required to complete the event-driven architecture and ensure consistent report notifications
### Closes 
closes: #133 



